### PR TITLE
Add Semi God Mode

### DIFF
--- a/vscripts/bots/Buff/Buff.lua
+++ b/vscripts/bots/Buff/Buff.lua
@@ -142,6 +142,10 @@ local bBuffFlags = {
         KillThreshold = 0,
         done = false,
     },
+    semigodmode = {
+        enabled = false, -- Toggled on via console command: semi_god_mode
+        StartTime = 0,
+    },
 }
 
 function Buff:Init()
@@ -156,6 +160,16 @@ function Buff:Init()
         GameRules:SendCustomMessage("Godmode StartTime:"..tostring(bBuffFlags.godmode.StartTime), -1, 0)
         GameRules:SendCustomMessage("Godmode KillThreshold:"..tostring(bBuffFlags.godmode.KillThreshold), -1, 0)
     end
+
+    if bBuffFlags.semigodmode.StartTime == 0 then
+        bBuffFlags.semigodmode.StartTime = RandomInt(10, 15)
+        GameRules:SendCustomMessage("Semi-godmode StartTime:"..tostring(bBuffFlags.semigodmode.StartTime).." min", -1, 0)
+    end
+
+    Convars:RegisterCommand("semi_god_mode", function()
+        bBuffFlags.semigodmode.enabled = true
+        GameRules:SendCustomMessage("Semi-god mode enabled!", -1, 0)
+    end, "Enable semi-god mode for bots", 0)
 
     Timers:CreateTimer(function()
         -- CheckBotCount()
@@ -258,7 +272,7 @@ function Buff:Init()
                         XP.UpdateXP(h, TeamRadiant, BotTotalKills, PlayerTotalKills)
                     end
                     if bBuffFlags.stats.radiant then
-                        isGodmodeDone = Stats.UpdateStats(h, TeamRadiant, BotTotalKills, PlayerTotalKills, bBuffFlags.godmode)
+                        isGodmodeDone = Stats.UpdateStats(h, TeamRadiant, BotTotalKills, PlayerTotalKills, bBuffFlags.godmode, bBuffFlags.semigodmode)
                     end
                 end
 
@@ -272,7 +286,7 @@ function Buff:Init()
                          XP.UpdateXP(h, TeamDire, BotTotalKills, PlayerTotalKills)
                     end
                     if bBuffFlags.stats.dire then
-                        isGodmodeDone = Stats.UpdateStats(h, TeamDire, BotTotalKills, PlayerTotalKills, bBuffFlags.godmode)
+                        isGodmodeDone = Stats.UpdateStats(h, TeamDire, BotTotalKills, PlayerTotalKills, bBuffFlags.godmode, bBuffFlags.semigodmode)
                     end
                 end
 

--- a/vscripts/bots/Buff/Stats.lua
+++ b/vscripts/bots/Buff/Stats.lua
@@ -5,15 +5,109 @@ then
     Stats = {}
 end
 
+local function GetBotPlayerID(bot)
+    local playerCount = PlayerResource:GetPlayerCount()
+    for playerID = 0, playerCount - 1 do
+        local player = PlayerResource:GetPlayer(playerID)
+        if player and player:GetAssignedHero() == bot then
+            return playerID
+        end
+    end
+    return nil
+end
+
+local SEMI_GOD_BUFF = 20
+local SEMI_GOD_DURATION = 30
+local SEMI_GOD_COOLDOWN = 600 -- 10 minutes in seconds
+
+function Stats.CheckSemiGodMode(bot, semigodmode)
+    if not semigodmode.enabled then return end
+
+    local now = GameRules:GetGameTime()
+
+    -- Expire active buff and revert stats
+    if bot.semigodmode_active and now >= bot.semigodmode_end_time then
+        bot:SetBaseStrength(bot:GetBaseStrength() - SEMI_GOD_BUFF)
+        bot:SetBaseAgility(bot:GetBaseAgility() - SEMI_GOD_BUFF)
+        bot:SetBaseIntellect(bot:GetBaseIntellect() - SEMI_GOD_BUFF)
+        bot.semigodmode_active = false
+        bot.semigodmode_cooldown_end = now + SEMI_GOD_COOLDOWN
+    end
+
+    -- Don't stack — skip if buff is already running
+    if bot.semigodmode_active then return end
+
+    -- Skip if on cooldown
+    if bot.semigodmode_cooldown_end and now < bot.semigodmode_cooldown_end then return end
+
+    -- Time threshold (in minutes)
+    local gameTime = Helper.DotaTime() / 60
+    if gameTime < semigodmode.StartTime then return end
+
+    -- Kill/death deficit for this bot
+    local playerID = GetBotPlayerID(bot)
+    if not playerID then return end
+    local deaths = PlayerResource:GetDeaths(playerID)
+    local kills  = PlayerResource:GetKills(playerID)
+    if (deaths - kills) <= 10 then return end
+
+    -- Bot must be under attack
+    local bBeingAttacked = false
+    local hEnemies = FindUnitsInRadius(
+        bot:GetTeam(), bot:GetAbsOrigin(), nil, 1200,
+        DOTA_UNIT_TARGET_TEAM_ENEMY,
+        DOTA_UNIT_TARGET_HERO + DOTA_UNIT_TARGET_CREEP + DOTA_UNIT_TARGET_COURIER,
+        DOTA_UNIT_TARGET_FLAG_NONE, FIND_ANY_ORDER, false
+    )
+    for _, enemy in pairs(hEnemies) do
+        if enemy:IsAlive() and enemy:GetAttackTarget() == bot then
+            bBeingAttacked = true
+            break
+        end
+    end
+    if not bBeingAttacked then return end
+
+    -- No allied heroes within 2000 radius
+    local hAllies = FindUnitsInRadius(
+        bot:GetTeam(), bot:GetAbsOrigin(), nil, 2000,
+        DOTA_UNIT_TARGET_TEAM_FRIENDLY,
+        DOTA_UNIT_TARGET_HERO,
+        DOTA_UNIT_TARGET_FLAG_NONE, FIND_ANY_ORDER, false
+    )
+    for _, ally in pairs(hAllies) do
+        if ally ~= bot and ally:IsAlive() and ally:IsHero() then
+            return
+        end
+    end
+
+    -- 5% chance to trigger
+    if RandomInt(1, 100) > 5 then return end
+
+    -- Apply semi-god mode
+    bot:SetBaseStrength(bot:GetBaseStrength() + SEMI_GOD_BUFF)
+    bot:SetBaseAgility(bot:GetBaseAgility() + SEMI_GOD_BUFF)
+    bot:SetBaseIntellect(bot:GetBaseIntellect() + SEMI_GOD_BUFF)
+    bot.semigodmode_active   = true
+    bot.semigodmode_end_time = now + SEMI_GOD_DURATION
+
+    GameRules:SendCustomMessage(
+        "<font color='#FFD700'>"..string.gsub(bot:GetUnitName(), 'npc_dota_hero_', '').."</font> entered semi-god mode for 30s!",
+        -1, 0
+    )
+    Say(bot, "I can do this all day.", false)
+end
+
 -- just eyeballed
-function Stats.UpdateStats(bot, nTeam, BotTotalKills, PlayerTotalKills, godmode)
+function Stats.UpdateStats(bot, nTeam, BotTotalKills, PlayerTotalKills, godmode, semigodmode)
     local gameTime = Helper.DotaTime() / 60
     local botPos = Helper.GetPosition(bot, nTeam)
     local unitStats = 1/60
 
-    if gameTime >= 10 and gameTime <=30 then 
+    Stats.CheckSemiGodMode(bot, semigodmode)
+
+    if gameTime >= 10 and gameTime <=30 then
         local stat
-        local bonus = unitStats * 1.3 -- add 1 stats per min 
+        local bonus = unitStats * 1.3 -- add 1 stats per min
         stat = bot:GetBaseStrength()
         bot:SetBaseStrength(stat + bonus)
         stat = bot:GetBaseAgility()
@@ -44,7 +138,7 @@ function Stats.UpdateStats(bot, nTeam, BotTotalKills, PlayerTotalKills, godmode)
         bot:SetBaseIntellect(stat + bonus)
         GameRules:SendCustomMessage("<font color='#70EA71'>"..string.gsub(bot:GetUnitName(), 'npc_dota_hero_', '').."</font>"..' is in god mode. Cautious!', -1, 0)
         return true
-    elseif gameTime > 40 and gameTime <=60 then  
+    elseif gameTime > 40 and gameTime <=60 then
         local stat
         local bonus = unitStats * 2 -- add 2 stats per min
         stat = bot:GetBaseStrength()

--- a/vscripts/bots/Buff/Stats.lua
+++ b/vscripts/bots/Buff/Stats.lua
@@ -16,9 +16,13 @@ local function GetBotPlayerID(bot)
     return nil
 end
 
-local SEMI_GOD_BUFF = 20
 local SEMI_GOD_DURATION = 30
 local SEMI_GOD_COOLDOWN = 600 -- 10 minutes in seconds
+
+-- starts at 20, +10 per every 10 minutes of game time
+local function GetSemiGodBuff(gameTime)
+    return 20 + math.floor(gameTime / 10) * 10
+end
 
 function Stats.CheckSemiGodMode(bot, semigodmode)
     if not semigodmode.enabled then return end
@@ -27,10 +31,12 @@ function Stats.CheckSemiGodMode(bot, semigodmode)
 
     -- Expire active buff and revert stats
     if bot.semigodmode_active and now >= bot.semigodmode_end_time then
-        bot:SetBaseStrength(bot:GetBaseStrength() - SEMI_GOD_BUFF)
-        bot:SetBaseAgility(bot:GetBaseAgility() - SEMI_GOD_BUFF)
-        bot:SetBaseIntellect(bot:GetBaseIntellect() - SEMI_GOD_BUFF)
+        local applied = bot.semigodmode_buff_applied
+        bot:SetBaseStrength(bot:GetBaseStrength() - applied)
+        bot:SetBaseAgility(bot:GetBaseAgility() - applied)
+        bot:SetBaseIntellect(bot:GetBaseIntellect() - applied)
         bot.semigodmode_active = false
+        bot.semigodmode_buff_applied = nil
         bot.semigodmode_cooldown_end = now + SEMI_GOD_COOLDOWN
     end
 
@@ -83,12 +89,14 @@ function Stats.CheckSemiGodMode(bot, semigodmode)
     -- 5% chance to trigger
     if RandomInt(1, 100) > 5 then return end
 
-    -- Apply semi-god mode
-    bot:SetBaseStrength(bot:GetBaseStrength() + SEMI_GOD_BUFF)
-    bot:SetBaseAgility(bot:GetBaseAgility() + SEMI_GOD_BUFF)
-    bot:SetBaseIntellect(bot:GetBaseIntellect() + SEMI_GOD_BUFF)
-    bot.semigodmode_active   = true
-    bot.semigodmode_end_time = now + SEMI_GOD_DURATION
+    -- Apply semi-god mode (buff scales with game time)
+    local buff = GetSemiGodBuff(gameTime)
+    bot:SetBaseStrength(bot:GetBaseStrength() + buff)
+    bot:SetBaseAgility(bot:GetBaseAgility() + buff)
+    bot:SetBaseIntellect(bot:GetBaseIntellect() + buff)
+    bot.semigodmode_active      = true
+    bot.semigodmode_buff_applied = buff
+    bot.semigodmode_end_time    = now + SEMI_GOD_DURATION
 
     GameRules:SendCustomMessage(
         "<font color='#FFD700'>"..string.gsub(bot:GetUnitName(), 'npc_dota_hero_', '').."</font> entered semi-god mode for 30s!",

--- a/vscripts/bots/Buff/Stats.lua
+++ b/vscripts/bots/Buff/Stats.lua
@@ -24,8 +24,9 @@ local function GetSemiGodBuff(gameTime)
     return 20 + math.floor(gameTime / 10) * 10
 end
 
-function Stats.CheckSemiGodMode(bot, semigodmode)
+function Stats.CheckSemiGodMode(bot, semigodmode, godmode)
     if not semigodmode.enabled then return end
+    if godmode.done then return end
 
     local now = GameRules:GetGameTime()
 
@@ -111,7 +112,7 @@ function Stats.UpdateStats(bot, nTeam, BotTotalKills, PlayerTotalKills, godmode,
     local botPos = Helper.GetPosition(bot, nTeam)
     local unitStats = 1/60
 
-    Stats.CheckSemiGodMode(bot, semigodmode)
+    Stats.CheckSemiGodMode(bot, semigodmode, godmode)
 
     if gameTime >= 10 and gameTime <=30 then
         local stat

--- a/vscripts/bots/Buff/Stats.lua
+++ b/vscripts/bots/Buff/Stats.lua
@@ -26,7 +26,6 @@ end
 
 function Stats.CheckSemiGodMode(bot, semigodmode, godmode)
     if not semigodmode.enabled then return end
-    if godmode.done then return end
 
     local now = GameRules:GetGameTime()
 
@@ -40,6 +39,8 @@ function Stats.CheckSemiGodMode(bot, semigodmode, godmode)
         bot.semigodmode_buff_applied = nil
         bot.semigodmode_cooldown_end = now + SEMI_GOD_COOLDOWN
     end
+
+    if godmode.done then return end
 
     -- Don't stack — skip if buff is already running
     if bot.semigodmode_active then return end


### PR DESCRIPTION
A new temporary buff system that activates under specific conditions to help struggling bots.

  How to enable:
  Type semi_god_mode in the console at the start of the game.

  Trigger conditions (all must be met):
  - Game time has passed a randomized threshold (10–15 min, set at game start)
  - The bot is actively being attacked by an enemy
  - No allied heroes within 2000 radius
  - The bot's deaths exceed its kills by more than 10
  - 5% random chance roll passes
  - Not on cooldown (10-minute cooldown between triggers)

  Effect:
  - Grants +20 base STR/AGI/INT at game start, scaling by +10 per 10 minutes of game time
  - Lasts 30 seconds, then fully reverts to previous stats
  - Bot broadcasts "I can do this all day." to all chat on trigger
  - A system message announces which hero entered semi-god mode (TODO: remove this if the mode is stable)